### PR TITLE
Split Variable into KeyVariable and LatVariable in API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+# Intellij specific settings
 target
 .idea
+project
 
 # Eclipse specific settings
 .project

--- a/src/main/scala/latmap/API.scala
+++ b/src/main/scala/latmap/API.scala
@@ -3,6 +3,8 @@ package latmap
 trait API {
   type Constant <: Term
   type Variable <: Term with APIVariable
+  type KeyVariable <: Variable
+  type LatVariable <: Variable
   type BodyElem <: APIBodyElem
   type Atom <: BodyElem with APIAtom
   type Const <: BodyElem
@@ -12,7 +14,8 @@ trait API {
   trait APIVariable extends Term {
     def :=(constant: Any): Const
   }
-  def variable(): Variable
+  def variable(): KeyVariable
+  def latVariable(lattice: Lattice): LatVariable
 
   trait APIRelation {
     def apply(terms: Term*): Atom

--- a/src/main/scala/latmap/Program.scala
+++ b/src/main/scala/latmap/Program.scala
@@ -1,12 +1,14 @@
 package latmap
 
 trait Program {
-  trait ProgVariable
+  trait ProgVariable {
+    def lattice: Option[Lattice]
+  }
   trait ProgBodyElem
   trait ProgAtom extends ProgBodyElem {
     def latMap: LatMap[_ <: Lattice]
-    def keyVars: Seq[Variable]
-    def latVar: Variable
+    def keyVars: Seq[KeyVariable]
+    def latVar: LatVariable
   }
   trait ProgConst extends ProgBodyElem {
     def variable: Variable
@@ -27,6 +29,8 @@ trait Program {
   }
 
   type Variable <: ProgVariable
+  type KeyVariable <: Variable
+  type LatVariable <: Variable
   type BodyElem <: ProgBodyElem
   type Atom <: ProgAtom
   type Const <: ProgConst

--- a/src/main/scala/latmap/Rule.scala
+++ b/src/main/scala/latmap/Rule.scala
@@ -2,7 +2,7 @@ package latmap
 
 trait Variable { val name: AnyRef }
 case class KeyVariable(name: AnyRef) extends Variable
-case class LatVariable(name: AnyRef) extends Variable
+case class LatVariable(name: AnyRef, lattice: Lattice) extends Variable
 
 case class Rule(headElement: RuleElement,
                 bodyElements: List[RuleElement]) {
@@ -111,7 +111,7 @@ class KeyConstantRuleElement(keyVar: Variable, const : Any) extends RuleElement 
 
 }
 
-class LatConstantRuleElement(latVar: Variable, const : Any, lattice : Lattice) extends RuleElement {
+class LatConstantRuleElement(latVar: LatVariable, const : Any, lattice : Lattice) extends RuleElement {
 
   override def variables: Seq[Variable] = Seq(latVar)
   override def costEstimate(boundVars: Set[Variable]): Int = {
@@ -123,13 +123,13 @@ class LatConstantRuleElement(latVar: Variable, const : Any, lattice : Lattice) e
       LatConstantFilter(
         regAlloc(latVar),
         const,
-        lattice
+        latVar.lattice
       )
     else
       LatConstantEval(
         regAlloc(latVar),
         const,
-        lattice
+        latVar.lattice
       )
   }
 

--- a/src/main/test/latmap/APITest2.scala
+++ b/src/main/test/latmap/APITest2.scala
@@ -6,7 +6,7 @@ object APITest2 extends App {
   {
     import p._
     val x = variable()
-    val l = variable()
+    val l = latVariable(ParityLattice)
     val one = variable()
     val two = variable()
     val three = variable()

--- a/src/main/test/latmap/SolverTest.scala
+++ b/src/main/test/latmap/SolverTest.scala
@@ -354,7 +354,7 @@ class SolverTest extends FunSuite {
 
     {
       import p._
-      val x = variable()
+      val x = latVariable(ParityLattice)
 
       val A = relation(1, ParityLattice)
 


### PR DESCRIPTION
This change stores the lattice element type in the variable itself - ensuring that `LatConstEval` and `LatConstFilter` are instantiated with the right lattice types.