### PR TITLE
Add .addIndex to API, fix bug in FilterFnRuleElement, check number of facts

### DIFF
--- a/src/main/scala/latmap/API.scala
+++ b/src/main/scala/latmap/API.scala
@@ -27,6 +27,7 @@ trait API {
   trait APIBodyElem
   trait APIAtom extends APIBodyElem {
     def :-(body: BodyElem*): Unit
+    def addIndex(terms: Term*): Unit
   }
 
   implicit def anyConst(a: Any): Constant

--- a/src/main/scala/latmap/API.scala
+++ b/src/main/scala/latmap/API.scala
@@ -19,6 +19,7 @@ trait API {
 
   trait APIRelation {
     def apply(terms: Term*): Atom
+    def numFacts(): Int
   }
   def relation(arity: Int, lattice: Lattice): Relation
   def relation(arity: Int): Relation

--- a/src/main/scala/latmap/APIImpl.scala
+++ b/src/main/scala/latmap/APIImpl.scala
@@ -30,6 +30,8 @@ class ProgramImpl extends Program {
     override def toString = result + " := " + function + arguments.mkString("(", ", ", ")")
   }
 
+  def addIndex(latMap: LatMap[_ <: Lattice], indices: Set[Int]): Unit = latMap.addIndex(new HashMapIndex(latMap, indices))
+
   val rules = mutable.ArrayBuffer[Rule]()
   override def toString = rules.mkString("\n")
 }
@@ -126,7 +128,7 @@ class APIImpl extends API {
         }
       }.toSet
 
-      latMap.addIndex(new HashMapIndex(latMap, indices))
+      program.addIndex(latMap, indices)
     }
   }
 

--- a/src/main/scala/latmap/APIImpl.scala
+++ b/src/main/scala/latmap/APIImpl.scala
@@ -116,11 +116,23 @@ class APIImpl extends API {
       //val newAtoms = if(latMap.lattice eq BoolLattice) atoms :+ Const(latVar, BoolLattice.top) else atoms
       //rules += Rule(this, newAtoms)
     }
+
+    override def addIndex(terms: Term*): Unit = {
+      val termsSet = terms.toSet
+      val indices = keyTerms.zipWithIndex.flatMap {
+        case (term, idx) => term match {
+          case kv: KeyVariable if termsSet.contains(kv) => Seq(idx)
+          case _ => Seq()
+        }
+      }.toSet
+
+      latMap.addIndex(new HashMapIndex(latMap, indices))
+    }
   }
 
   case class Const(variable: Term, constant: Any) extends BodyElem {
     override def convert(termToVar: (Term, Option[Lattice]) => program.Variable): program.Const =
-      program.Const(termToVar(variable, None), constant)
+    program.Const(termToVar(variable, None), constant)
   }
 
   case class Constant(constant: Any) extends Term

--- a/src/main/scala/latmap/APIImpl.scala
+++ b/src/main/scala/latmap/APIImpl.scala
@@ -64,6 +64,8 @@ class APIImpl extends API {
       val newVars = if(lattice eq BoolLattice) vars :+ Constant(BoolLattice.top) else vars
       Atom(latMap, newVars.dropRight(1), newVars.last)
     }
+
+    def numFacts(): Int = latMap.numFacts()
   }
 
   def relation(arity: Int, lattice: Lattice): Relation = {

--- a/src/main/scala/latmap/HashMapIndex.scala
+++ b/src/main/scala/latmap/HashMapIndex.scala
@@ -34,7 +34,8 @@ class HashMapIndex(
       }
       
       def isEmptyEntry = store(pos * entryLen) == empty
-      
+
+      // advance pos to next match or empty entry
       def validatePosn() = {
           do {
               pos &= mask

--- a/src/main/scala/latmap/Program.scala
+++ b/src/main/scala/latmap/Program.scala
@@ -39,4 +39,5 @@ trait Program {
   type Rule <: ProgRule
 
   def rules: Seq[Rule]
+  def addIndex(latMap: LatMap[_ <: Lattice], indices: Set[Int]): Unit
 }

--- a/src/main/scala/latmap/Rule.scala
+++ b/src/main/scala/latmap/Rule.scala
@@ -65,7 +65,7 @@ class LatmapRuleElement(_latmapGroup: LatMapGroup, vars: Seq[Variable], constRul
          */
         IndexScan(
           //latmap.selectIndex(vars.zipWithIndex.collect { case (e, i) if boundVars.contains(e) => i }.toSet),
-          latmapGroup.get(latmapType.get).selectIndex(boundVars.filter(keyVars.contains(_)).map(vars.indexOf(_)).filter(_ >= 0)),
+          latmapGroup.get(latmapType.get).selectIndex(boundVars.intersect(keyVars.toSet).map(vars.indexOf(_))),
           mergeLat = false,
           inputRegs = keyVars.map(regAlloc).toArray,
           outputRegs = keyVars.map(regAlloc).toArray,
@@ -159,7 +159,7 @@ class FilterFnRuleElement(function: AnyRef, vars: Seq[Variable])
   extends RuleElement {
   override def variables: Seq[Variable] = vars
   override def costEstimate(boundVars: Set[Variable]): Int = {
-    0
+    if (boundVars.subsetOf(vars.toSet)) 0 else Int.MaxValue
   }
   override def planElement(boundVars: Set[Variable], regAlloc: Variable=>Int, latmapType : Option[LatMapType] = None): PlanElement = {
     FilterFn(vars.map(regAlloc).toArray, function)

--- a/src/main/test/latmap/LongSolverTest.scala
+++ b/src/main/test/latmap/LongSolverTest.scala
@@ -42,17 +42,17 @@ class LongSolverTest extends FunSuite {
       val z = latVariable(SULattice)
 
       // AddrO
-      Pt(p,a) :- AddrOf(p,a)
+      Pt(pvar,a) :- AddrOf(pvar,a)
 
       // Copy
-      Pt(p,a) :- (Copy(p,q), Pt(q,a))
+      Pt(pvar,a) :- (Copy(pvar,q), Pt(q,a))
 
       // Store
       def toSingle(x: String) = SULattice.Single(x)
       SU(l,a,z) :- (Store(l,pvar,q), Pt(pvar,a), Pt(q,b), T(z, toSingle, b))
 
-      PtH(a,b) :- (Store(l,pvar,q), Pt(p,a), Pt(q,b))
-      PtH(a,b) :- (FIStore(p,q,l), Pt(p,a), Pt(q,b))
+      PtH(a,b) :- (Store(l,pvar,q), Pt(pvar,a), Pt(q,b))
+      PtH(a,b) :- (FIStore(pvar,q,l), Pt(pvar,a), Pt(q,b))
 
       // Load
       def filter(e: SULattice.Elem, p:String): Boolean = e match {
@@ -61,8 +61,8 @@ class LongSolverTest extends FunSuite {
         case SULattice.Top => true
       }
 
-      Pt(p,b) :- (Load(l,p,q), Pt(q,a), F(filter,t,b), PtH(a,b), SU(l,a,t))
-      Pt(p,b) :- (FILoad(p,q,l), Pt(q,a), PtH(a,b))
+      Pt(pvar,b) :- (Load(l,pvar,q), Pt(q,a), F(filter,t,b), PtH(a,b), SU(l,a,t))
+      Pt(pvar,b) :- (FILoad(pvar,q,l), Pt(q,a), PtH(a,b))
 
       // Preserve
       def killNot(a: String, e: SULattice.Elem): Boolean = e match {
@@ -77,7 +77,7 @@ class LongSolverTest extends FunSuite {
       SU(l,a,z) :- (Clear(l), PtH(a,b), T(z,toSingle,b))
 
       // Kill
-      Kill(l,z) :- (Store(l,pvar,q), Pt(p,b), T(z,toSingle,b))
+      Kill(l,z) :- (Store(l,pvar,q), Pt(pvar,b), T(z,toSingle,b))
       Kill(l, SULattice.Top) :- Phi(l)
 
       // Example facts
@@ -120,11 +120,14 @@ class LongSolverTest extends FunSuite {
         ("PtH", PtH),
         ("Kill", Kill)
       ))
+
+      p.solve()
+
+      assert(Pt.numFacts() == 469)
+      println(Pt.numFacts())
     }
 
     println(p.asInstanceOf[APIImpl].program)
-
-    p.solve()
   }
 
 }

--- a/src/main/test/latmap/LongSolverTest.scala
+++ b/src/main/test/latmap/LongSolverTest.scala
@@ -3,7 +3,7 @@ package latmap
 import org.scalatest.FunSuite
 
 class LongSolverTest extends FunSuite {
-  test("SUopt") {
+  test("StrongUpdate tests") {
     val p = API()
 
     {
@@ -24,14 +24,6 @@ class LongSolverTest extends FunSuite {
       // Outputs
       val Pt = relation(2)
 
-      val SU = relation(2, SULattice)
-
-      val PtH = relation(2)
-      val Kill = relation(1, SULattice)
-
-      // Rules
-      // ----------
-      //
       val pvar = variable()
       val a = variable()
       val b = variable()
@@ -40,6 +32,40 @@ class LongSolverTest extends FunSuite {
       val q = variable()
       val t = latVariable(SULattice)
       val z = latVariable(SULattice)
+
+      // Indexes
+      AddrOf(a,b).addIndex(a,b)
+      Copy(a,b).addIndex(a,b)
+      Copy(a,b).addIndex(a)
+      Store(a,b,k).addIndex(a,b,k)
+      Store(a,b,k).addIndex(b)
+      Store(a,b,k).addIndex(k)
+      Load(a,b,k).addIndex(a,b,k)
+      Load(a,b,k).addIndex(a)
+      Load(a,b,k).addIndex(k)
+      CFG(a,b).addIndex(a,b)
+      CFG(a,b).addIndex(a)
+      CFG(a,b).addIndex(b)
+      FIStore(a,b,k).addIndex(a)
+      FIStore(a,b,k).addIndex(b)
+      FILoad(a,b,k).addIndex(b)
+
+      Pt(a,b).addIndex(a,b)
+      Pt(a,b).addIndex(a)
+
+      val SU = relation(2, SULattice)
+      SU(a,b,t).addIndex(a,b)
+      SU(a,b,t).addIndex(a)
+
+      val PtH = relation(2)
+      PtH(a,b).addIndex(a,b)
+      PtH(a,b).addIndex(a)
+      val Kill = relation(1, SULattice)
+
+      // Rules
+      // ----------
+      //
+
 
       // AddrO
       Pt(pvar,a) :- AddrOf(pvar,a)
@@ -104,6 +130,7 @@ class LongSolverTest extends FunSuite {
 //      CFG("l5","l6") :- ()
 //      CFG("l6","l7") :- ()
 
+      // Update the file name below to any .flix fact file that's in the test.latmap.testdata folder.
       loadFactsFromFile(this.getClass.getResource("/470.lbm.flix").getPath, Map(
         ("AddrOf", AddrOf),
         ("Copy", Copy),
@@ -123,8 +150,9 @@ class LongSolverTest extends FunSuite {
 
       p.solve()
 
+      // 469 facts should be in the output for 470.lbm.flix; update this number for other fact files.
       assert(Pt.numFacts() == 469)
-      println(Pt.numFacts())
+
     }
 
     println(p.asInstanceOf[APIImpl].program)


### PR DESCRIPTION
Also update strong update tests to use the index API to add HashMap indexes. Runtime of LongSolverTests.StrongUpdateTest goes down from 12 seconds to 5 seconds with these indexes.