### PR TITLE
Add NoOp, DeadEnd PlanElements that are eliminated in Planner

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,5 +14,6 @@ lazy val latmap = (project in file("."))
     name := "latmap",
     scalaSource in Compile := baseDirectory.value / "src" / "main" / "scala",
     scalaSource in Test := baseDirectory.value / "src" / "main" / "test",
+    resourceDirectory in Test := baseDirectory.value / "src" / "main" / "test" / "latmap" / "testdata",
     libraryDependencies ++= dependencies
   )

--- a/src/main/scala/latmap/Plan.scala
+++ b/src/main/scala/latmap/Plan.scala
@@ -213,13 +213,11 @@ case class IndexScan(index: Index,
         i = i + 1
       }
 
-      // TODO: Delete this all in BoolIndexScan
       var newLat = latticeMap.get(outputs)
       val lattice: Lattice = latticeMap.lattice
       if (mergeLat)
         newLat = latticeMap.lattice.glb(newLat, evalContext.latRegs(outputLatReg - 1000).asInstanceOf[latticeMap.lattice.Elem])
-      if (lattice != BoolLattice)
-        evalContext.latRegs(outputLatReg - 1000) = newLat
+      evalContext.latRegs(outputLatReg - 1000) = newLat
 
       if (newLat != lattice.bottom)
         next.go(evalContext)
@@ -366,4 +364,24 @@ case class WriteToLatMap(inputRegs: Array[Int],
     if (next != null)
       next.go(evalContext)
   }
+}
+
+/**
+  * Calls the next plan element without doing anything.
+  *
+  * Eliminated in planner (i.e. never run)
+  */
+case class NoOp() extends PlanElement {
+  override def go(evalContext: EvalContext): Unit = {
+    next.go(evalContext)
+  }
+}
+
+/**
+  * Signals a dead end in a chain of PlanElements.
+  *
+  * Everything after this PlanElement is eliminated by planner (i.e. never run)
+  */
+case class DeadEnd() extends PlanElement {
+  override def go(evalContext: EvalContext): Unit = {}
 }

--- a/src/main/scala/latmap/Planner.scala
+++ b/src/main/scala/latmap/Planner.scala
@@ -29,8 +29,24 @@ class Planner {
     val remaining = mutable.Set(rule.bodyElements:_*)
     var curPlanElement: Option[PlanElement] = None
     var initPlanElement: Option[PlanElement] = curPlanElement
+    var pastDeadEnd = false
 
     def addPlanElement(pe: PlanElement, re: RuleElement): Unit = {
+      // Eliminate NoOps and DeadEnds
+      if (pastDeadEnd) {
+        remaining.remove(re)
+        return
+      }
+
+      pe match {
+        case x: NoOp =>
+          remaining.remove(re)
+          return
+        case x: DeadEnd =>
+          pastDeadEnd = true
+        case _ =>
+      }
+
       curPlanElement match {
         case Some(cur) =>
           cur.next = pe

--- a/src/main/scala/latmap/Rule.scala
+++ b/src/main/scala/latmap/Rule.scala
@@ -63,14 +63,14 @@ class LatmapRuleElement(_latmapGroup: LatMapGroup, vars: Seq[Variable], constRul
           make a better index
           call Index scan with better index
          */
-        /*latmapGroup.get(latmapType.get).lattice match {
+        latmapGroup.get(latmapType.get).lattice match {
           case BoolLattice =>
             BoolIndexScan(
               latmapGroup.get(latmapType.get).selectIndex(boundVars.intersect(keyVars.toSet).map(vars.indexOf(_))),
               inputRegs = keyVars.map(regAlloc).toArray,
               outputRegs = keyVars.map(regAlloc).toArray
             )
-          case _ =>*/
+          case _ =>
             IndexScan(
               //latmap.selectIndex(vars.zipWithIndex.collect { case (e, i) if boundVars.contains(e) => i }.toSet),
               latmapGroup.get(latmapType.get).selectIndex(boundVars.intersect(keyVars.toSet).map(vars.indexOf(_))),
@@ -79,7 +79,7 @@ class LatmapRuleElement(_latmapGroup: LatMapGroup, vars: Seq[Variable], constRul
               outputRegs = keyVars.map(regAlloc).toArray,
               outputLatReg = regAlloc(latVar)
             )
-        //}
+        }
     }
   }
   override def writeToLatMap(regAlloc: Variable=>Int): PlanElement = {
@@ -127,18 +127,26 @@ class LatConstantRuleElement(latVar: LatVariable, const : Any, lattice : Lattice
   }
   override def planElement(boundVars: Set[Variable], regAlloc: Variable=>Int, latmapType : Option[LatMapType] = None): PlanElement = {
     // TODO: split up, using boundvars
-    if (boundVars.contains(latVar))
-      LatConstantFilter(
-        regAlloc(latVar),
-        const,
-        latVar.lattice
-      )
-    else
-      LatConstantEval(
-        regAlloc(latVar),
-        const,
-        latVar.lattice
-      )
+    if (lattice == BoolLattice) {
+      if (const == true) {
+        NoOp()
+      } else {
+        DeadEnd()
+      }
+    } else {
+      if (boundVars.contains(latVar))
+        LatConstantFilter(
+          regAlloc(latVar),
+          const,
+          latVar.lattice
+        )
+      else
+        LatConstantEval(
+          regAlloc(latVar),
+          const,
+          latVar.lattice
+        )
+    }
   }
 
 }

--- a/src/main/test/latmap/APITest.scala
+++ b/src/main/test/latmap/APITest.scala
@@ -9,9 +9,10 @@ object APITest extends App {
     val y = variable()
     val z = variable()
     val dist = relation(2)
-    dist(x, z) :- (dist(x, y), dist(y, z))
     dist(1, 2) :- ()
     dist(2, 3) :- ()
+    dist(x, z) :- (dist(x, y), dist(y, z))
+
     def filter(x: Int, y: Int) = true
     dist(x, z) :- (dist(x, y), dist(y, z), F(filter, x, z))
     def transfer(x: Int, y: Int) = x+y

--- a/src/main/test/latmap/SolverTest.scala
+++ b/src/main/test/latmap/SolverTest.scala
@@ -495,4 +495,26 @@ class SolverTest extends FunSuite {
 
     p.solve()
   }
+  test("DeadEnd1"){
+    val p = API()
+
+    {
+      import p._
+
+      val A = relation(2, ParityLattice)
+      val x = variable()
+      val y = variable()
+      val z = latVariable(ParityLattice)
+      A(0,1,ParityLattice.top) :- ()
+      A(1,2,ParityLattice.bottom) :- ()
+      A(x,y,z) :- (A(x,y,ParityLattice.bottom), A(0,x,z))
+
+      println(p.asInstanceOf[APIImpl].program)
+      solve()
+
+      // Only the top fact was written
+      assert(A.numFacts() == 1)
+    }
+
+  }
 }


### PR DESCRIPTION
This PR adds two new PlanElements that are used by the LatConstantRuleElement to avoid evaluation of lattice constants in the BoolLattice case during plan execution.

This change also re-activates BoolIndexScan, which was added but disabled in a previous commit.